### PR TITLE
feat-Refresh Token 기능 추가

### DIFF
--- a/backend/prisma/migrations/20250328014409_add_refresh_token/migration.sql
+++ b/backend/prisma/migrations/20250328014409_add_refresh_token/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `refreshToken` VARCHAR(191) NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   password     String?          // 일반 로그인만 해당
   nickname     String
   regionId     Int
+  refreshToken String?
   region       Region           @relation(fields: [regionId], references: [id])
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @updatedAt

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
-
-const secret = process.env.JWT_SECRET as string;
+import { verify } from '../utils/jwt';
 
 export interface AuthRequest extends Request {
   userId?: number;
@@ -18,8 +16,7 @@ export const verifyToken = (req: AuthRequest, res: Response, next: NextFunction)
   const token = authHeader.split(' ')[1];
 
   try {
-    const decoded = jwt.verify(token, secret) as { userId: number };
-    req.userId = decoded.userId;
+    req.userId = verify<{ userId: number }>(token).userId;
     next();
   } catch {
     res.status(401).json({ error: '유효하지 않은 토큰입니다.' });

--- a/backend/src/routes/auth.docs.ts
+++ b/backend/src/routes/auth.docs.ts
@@ -1,6 +1,6 @@
 /**
  * @swagger
- * /auth/signup:
+ * /api/auth/signup:
  *   post:
  *     summary: 회원가입
  *     tags: [Auth]
@@ -33,7 +33,7 @@
 
 /**
  * @swagger
- * /auth/login:
+ * /api/auth/login:
  *   post:
  *     summary: 로그인
  *     tags: [Auth]
@@ -60,7 +60,7 @@
 
 /**
  * @swagger
- * /auth/me:
+ * /api/auth/me:
  *   get:
  *     summary: 내 정보 조회
  *     tags: [Auth]
@@ -87,4 +87,30 @@
  *                       type: integer
  *       401:
  *         description: 인증 실패 (토큰 없음 또는 유효하지 않음)
+ */
+
+/**
+ * @swagger
+ * /api/auth/refresh:
+ *   post:
+ *     summary: Access Token 재발급
+ *     tags: [Auth]
+ *     description: 클라이언트는 쿠키에 담긴 Refresh Token을 전송하여 새로운 Access Token을 발급받습니다.
+ *     requestBody:
+ *       required: false
+ *     responses:
+ *       200:
+ *         description: 토큰 재발급 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 토큰이 재발급되었습니다.
+ *       401:
+ *         description: 유효하지 않은 Refresh Token
+ *       403:
+ *         description: Refresh Token이 유효하지 않음 (DB 불일치 등)
  */

--- a/backend/src/routes/auth.route.ts
+++ b/backend/src/routes/auth.route.ts
@@ -7,4 +7,5 @@ const router = express.Router();
 router.post('/signup', authController.signup);
 router.post('/login', authController.login);
 router.get('/me', verifyToken, authController.me);
+router.post('/refresh', authController.refresh);
 export default router;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,6 +1,6 @@
 import prisma from '../config/prisma';
 import bcrypt from 'bcrypt';
-import { signToken } from '../utils/jwt';
+import { signRefreshToken, signToken } from '../utils/jwt';
 
 interface SignupInput {
   email: string;
@@ -53,8 +53,15 @@ export const login = async (input: LoginInput) => {
   }
 
   const token = signToken({ userId: user.id });
+  const refreshToken = signRefreshToken({ userId: user.id });
 
+  // DB에 저장
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { refreshToken },
+  });
   return {
     token,
+    refreshToken,
   };
 };

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -5,7 +5,17 @@ const secret = process.env.JWT_SECRET as string;
 
 export const signToken = (payload: object) => {
   const options: SignOptions = {
-    expiresIn: process.env.JWT_EXPIRES_IN ? parseInt(process.env.JWT_EXPIRES_IN) : '1h',
+    expiresIn: process.env.JWT_EXPIRES_IN ? parseInt(process.env.JWT_EXPIRES_IN) : '15m',
   };
   return jwt.sign(payload, secret, options);
+};
+
+export const signRefreshToken = (payload: object): string => {
+  return jwt.sign(payload, process.env.JWT_SECRET as string, {
+    expiresIn: '7d', // 또는 process.env.JWT_REFRESH_EXPIRES_IN
+  });
+};
+
+export const verify = <TPayload extends object>(token: string): TPayload => {
+  return jwt.verify(token, secret) as TPayload;
 };


### PR DESCRIPTION
 * /api/auth/refresh:
 - 토큰 재발급
  - 토큰 들어있는지 검증
  - DB에 저장된 Refresh Token 검증
  - 새 토큰 발급
  - Refresh Token 갱신
  - 쿠키로 다시 전송